### PR TITLE
Fix: multiple ontologies passed as comma-separated string cause `Unknown database` error

### DIFF
--- a/src/langchain_timbr/utils/timbr_llm_utils.py
+++ b/src/langchain_timbr/utils/timbr_llm_utils.py
@@ -304,7 +304,8 @@ def determine_concept(
     if timeout is None:
         timeout = config.llm_timeout
     
-    determine_concept_prompt = get_determine_concept_prompt_template(conn_params)
+    # Fix for multiple ontologies - load the prompt template using a specific ontology connection
+    determine_concept_prompt = None
 
     ontologies_conn_params = {}
     #ontologies = [o.strip().lower() for o in conn_params.get("ontology").split(",")]
@@ -314,6 +315,10 @@ def determine_concept(
         ontology_conn_param =  conn_params.copy()
         ontology_conn_param["ontology"] = ontology
         ontologies_conn_params[ontology] = ontology_conn_param
+        
+        # Fix for multiple ontologies
+        if not determine_concept_prompt:
+            determine_concept_prompt = get_determine_concept_prompt_template(ontology_conn_param)
 
     concepts_desc_arr = []
     ontologies_concepts_and_views = {}

--- a/src/langchain_timbr/utils/timbr_utils.py
+++ b/src/langchain_timbr/utils/timbr_utils.py
@@ -127,7 +127,11 @@ def run_query(sql: str, conn_params: dict, llm_prompt: Optional[str] = None, use
         clean_prompt = llm_prompt.replace('\r\n', ' ').replace('\n', ' ').replace('?', '')
         query = f"-- LLM: {clean_prompt}\n{sql}"
 
-    query_conn_params = conn_params
+    # Fix for multiple ontologies - load the prompt template using a specific ontology connection
+    query_conn_params = conn_params.copy()
+    if 'ontology' in conn_params and conn_params['ontology'] and ',' in conn_params['ontology']:
+        query_conn_params['ontology'] = query_conn_params['ontology'].split(',')[0].strip()
+
     if not use_query_limit:
         # Remove results-limit
         if 'additional_headers' in conn_params and 'results-limit' in conn_params['additional_headers']:
@@ -179,7 +183,9 @@ def get_timbr_agent_options(agent_name: str, conn_params: dict) -> dict:
     # Query agent options (case-insensitive match on agent_name)
     options_query = f"SELECT option_name, option_value FROM timbr.sys_agents_options WHERE LOWER(agent_name) = LOWER('{agent_name}')"
     
-    results = run_query(options_query, conn_params)
+    # Fix for multiple ontologies - load the prompt template using a specific ontology connection
+    use_ontology = "system_db" if conn_params.get("ontology") and ',' in conn_params.get("ontology") else conn_params.get("ontology")
+    results = run_query(options_query, {**conn_params, "ontology": use_ontology})
     if len(results) == 0:
         raise Exception(f'Agent "{agent_name}" not found or has no options defined.')
     for row in results:

--- a/tests/standard/test_multi_ontology.py
+++ b/tests/standard/test_multi_ontology.py
@@ -1,0 +1,128 @@
+"""Unit tests for the multiple ontologies bug fix.
+
+These tests cover the case where conn_params['ontology'] is a comma-separated
+string (e.g. "ontology_a,ontology_b"), which previously caused a DatabaseError:
+  Unknown database 'ontology_a,ontology_b'
+"""
+import pytest
+from unittest.mock import Mock, patch
+
+from langchain_timbr.utils.timbr_utils import run_query, get_timbr_agent_options
+from langchain_timbr.utils.timbr_llm_utils import determine_concept
+
+MOCK_URL = "http://test-timbr-url"
+MOCK_TOKEN = "test-token"
+
+
+class TestMultiOntologyFix:
+    """Tests for the bug fix that handles comma-separated ontology strings."""
+
+    # ------------------------------------------------------------------ #
+    # run_query                                                            #
+    # ------------------------------------------------------------------ #
+
+    @patch("langchain_timbr.utils.timbr_utils.timbr_http_connector")
+    def test_run_query_multi_ontology_uses_first_ontology(self, mock_connector):
+        """run_query must strip to the first ontology when a comma-separated list is given."""
+        mock_connector.run_query.return_value = []
+        conn_params = {"url": MOCK_URL, "token": MOCK_TOKEN, "ontology": "ontology_a,ontology_b"}
+
+        run_query("SELECT 1", conn_params)
+
+        kwargs = mock_connector.run_query.call_args.kwargs
+        assert kwargs["ontology"] == "ontology_a"
+
+    @patch("langchain_timbr.utils.timbr_utils.timbr_http_connector")
+    def test_run_query_does_not_mutate_conn_params(self, mock_connector):
+        """run_query must not mutate the caller's conn_params dict."""
+        mock_connector.run_query.return_value = []
+        conn_params = {"url": MOCK_URL, "token": MOCK_TOKEN, "ontology": "ontology_a,ontology_b"}
+
+        run_query("SELECT 1", conn_params)
+
+        assert conn_params["ontology"] == "ontology_a,ontology_b"
+
+    @patch("langchain_timbr.utils.timbr_utils.timbr_http_connector")
+    def test_run_query_multi_ontology_strips_whitespace(self, mock_connector):
+        """run_query must strip surrounding whitespace from the first ontology."""
+        mock_connector.run_query.return_value = []
+        conn_params = {"url": MOCK_URL, "token": MOCK_TOKEN, "ontology": " ontology_a , ontology_b "}
+
+        run_query("SELECT 1", conn_params)
+
+        kwargs = mock_connector.run_query.call_args.kwargs
+        assert kwargs["ontology"] == "ontology_a"
+
+    @patch("langchain_timbr.utils.timbr_utils.timbr_http_connector")
+    def test_run_query_single_ontology_unchanged(self, mock_connector):
+        """run_query must leave a single (non-comma) ontology value unchanged."""
+        mock_connector.run_query.return_value = []
+        conn_params = {"url": MOCK_URL, "token": MOCK_TOKEN, "ontology": "ontology_a"}
+
+        run_query("SELECT 1", conn_params)
+
+        kwargs = mock_connector.run_query.call_args.kwargs
+        assert kwargs["ontology"] == "ontology_a"
+
+    # ------------------------------------------------------------------ #
+    # get_timbr_agent_options                                              #
+    # ------------------------------------------------------------------ #
+
+    @patch("langchain_timbr.utils.timbr_utils.timbr_http_connector")
+    def test_get_timbr_agent_options_uses_system_db_for_multi_ontology(self, mock_connector):
+        """get_timbr_agent_options must query system_db when multiple ontologies are present."""
+        mock_connector.run_query.return_value = [
+            {"option_name": "ontology", "option_value": "ontology_a,ontology_b"}
+        ]
+        conn_params = {"url": MOCK_URL, "token": MOCK_TOKEN, "ontology": "ontology_a,ontology_b"}
+
+        get_timbr_agent_options("my_agent", conn_params)
+
+        kwargs = mock_connector.run_query.call_args.kwargs
+        assert kwargs["ontology"] == "system_db"
+
+    @patch("langchain_timbr.utils.timbr_utils.timbr_http_connector")
+    def test_get_timbr_agent_options_single_ontology_unchanged(self, mock_connector):
+        """get_timbr_agent_options must pass the single ontology through unchanged."""
+        mock_connector.run_query.return_value = [
+            {"option_name": "ontology", "option_value": "ontology_a"}
+        ]
+        conn_params = {"url": MOCK_URL, "token": MOCK_TOKEN, "ontology": "ontology_a"}
+
+        get_timbr_agent_options("my_agent", conn_params)
+
+        kwargs = mock_connector.run_query.call_args.kwargs
+        assert kwargs["ontology"] == "ontology_a"
+
+    # ------------------------------------------------------------------ #
+    # determine_concept                                                    #
+    # ------------------------------------------------------------------ #
+
+    @patch("langchain_timbr.utils.timbr_llm_utils.get_concepts")
+    @patch("langchain_timbr.utils.timbr_llm_utils.get_ontology_description")
+    @patch("langchain_timbr.utils.timbr_llm_utils.get_tags")
+    @patch("langchain_timbr.utils.timbr_llm_utils.get_determine_concept_prompt_template")
+    def test_determine_concept_prompt_template_uses_single_ontology(
+        self, mock_get_prompt, mock_get_tags, mock_get_ontology_desc, mock_get_concepts
+    ):
+        """get_determine_concept_prompt_template must be called with a single-ontology
+        conn_param, not the raw comma-separated string."""
+        mock_get_prompt.return_value = Mock()
+        mock_get_tags.return_value = {"concept_tags": {}, "view_tags": {}}
+        mock_get_ontology_desc.return_value = ("", "")
+        # Only ontology_a returns a concept; ontology_b is empty
+        mock_get_concepts.side_effect = lambda conn_params=None, **_: (
+            {"city": {"concept": "city", "description": "a city", "is_view": "false"}}
+            if conn_params and conn_params.get("ontology") == "ontology_a"
+            else {}
+        )
+
+        conn_params = {"url": MOCK_URL, "token": MOCK_TOKEN, "ontology": "ontology_a,ontology_b"}
+        determine_concept("What are the cities?", Mock(), conn_params)
+
+        # Prompt template must be built exactly once (not once per ontology)
+        mock_get_prompt.assert_called_once()
+        # The call must use a single-ontology conn_param (first one in the list)
+        called_conn_params = mock_get_prompt.call_args[0][0]
+        assert called_conn_params["ontology"] == "ontology_a"
+        assert "," not in called_conn_params["ontology"]


### PR DESCRIPTION
### Description
<!--- Copy a summary or requirements of the bug/features section of the JIRA ticket -->
When a user passes multiple ontologies as a comma-separated string (e.g. `"ontology_a,ontology_b"`) — either directly or via an agent — the raw string was forwarded to the database driver as-is. This caused a hard failure at query time:

```
Error running query: java.sql.SQLException: Unknown database 'ontology_a,ontology_b'
```

### Type of Change
<!--- Check any relevant boxes with "x" -->
- [ ] New feature | task (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change

### TESTS
<!--- Specify number of tests added or changed -->
Number of tests added/changed: 
`tests/standard/test_multi_ontology.py` — 7 new unit tests, all mocked (no real connection required):

| Test | Covers |
|---|---|
| `test_run_query_multi_ontology_uses_first_ontology` | Connector receives `"ontology_a"` when given `"ontology_a,ontology_b"` |
| `test_run_query_does_not_mutate_conn_params` | Original `conn_params` dict is not modified |
| `test_run_query_multi_ontology_strips_whitespace` | Handles `" ontology_a , ontology_b "` correctly |
| `test_run_query_single_ontology_unchanged` | Single-ontology path is unaffected |
| `test_get_timbr_agent_options_uses_system_db_for_multi_ontology` | Routes to `"system_db"` for multi-ontology agent option queries |
| `test_get_timbr_agent_options_single_ontology_unchanged` | Single-ontology path passes through unchanged |
| `test_determine_concept_prompt_template_uses_single_ontology` | Prompt template built with a single-ontology `conn_params`, called exactly once |


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Enter the ticket number as TP-XXXX format -->
- [ ] JIRA Ticket: 
- [ ] Has associated issue: 
- [ ] Removes existing feature or API
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
