### PR TITLE
Feature/TP 3320 agent history monitoring should conatin missing parameters

### DIFF
--- a/src/langchain_timbr/langchain/execute_timbr_query_chain.py
+++ b/src/langchain_timbr/langchain/execute_timbr_query_chain.py
@@ -350,6 +350,7 @@ class ExecuteTimbrQueryChain(Chain):
             _log_ctx = AgentLogContext(
                 query_id=_query_id,
                 agent_name=self._agent or "",
+                ontology=ontology_name or "",
                 url=build_server_url(self._url, config.thrift_host, config.thrift_port),
                 token=self._token,
                 chain_type="ExecuteTimbrQueryChain",
@@ -459,7 +460,6 @@ class ExecuteTimbrQueryChain(Chain):
             final_error = error if not is_sql_valid else None
 
             _total_duration_ms = int((_now() - _chain_start).total_seconds() * 1000)
-            _chain_ctx = self._received_chain_context
             _chain_ctx["duration"]["ExecuteTimbrQueryChain"] = _total_duration_ms
             if _generate_sql_chain_duration_ms:
                 _chain_ctx["duration"]["GenerateTimbrSqlChain"] = _generate_sql_chain_duration_ms

--- a/src/langchain_timbr/langchain/execute_timbr_query_chain.py
+++ b/src/langchain_timbr/langchain/execute_timbr_query_chain.py
@@ -326,6 +326,7 @@ class ExecuteTimbrQueryChain(Chain):
         identify_concept_reason = None
         generate_sql_reason = None
         _generate_sql_chain_duration_ms = 0
+        _reasoning_duration_ms = 0
 
         # ---- memory resolution (once per top-level invocation) ----
         _chain_ctx = self._received_chain_context
@@ -401,6 +402,7 @@ class ExecuteTimbrQueryChain(Chain):
                     _gen_start = _now()
                     generate_res = self._generate_sql(prompt, sql, concept_name, schema_name, error, conn_params, memory_context=memory_ctx)
                     _generate_sql_chain_duration_ms += int((_now() - _gen_start).total_seconds() * 1000)
+                    _reasoning_duration_ms += generate_res.get("reasoning_duration", 0) or 0
                     conn_params = generate_res.get("conn_params")
                     sql = generate_res.get("sql", "")
                     ontology_name = generate_res.get("ontology", ontology_name)
@@ -463,6 +465,7 @@ class ExecuteTimbrQueryChain(Chain):
             _chain_ctx["duration"]["ExecuteTimbrQueryChain"] = _total_duration_ms
             if _generate_sql_chain_duration_ms:
                 _chain_ctx["duration"]["GenerateTimbrSqlChain"] = _generate_sql_chain_duration_ms
+            _chain_ctx["duration"]["reasoning"] = _reasoning_duration_ms
             if identify_concept_reason:
                 _chain_ctx["reasoning"]["identify_concept_reason"] = identify_concept_reason
             if generate_sql_reason:

--- a/src/langchain_timbr/langchain/execute_timbr_query_chain.py
+++ b/src/langchain_timbr/langchain/execute_timbr_query_chain.py
@@ -327,6 +327,7 @@ class ExecuteTimbrQueryChain(Chain):
         generate_sql_reason = None
         _generate_sql_chain_duration_ms = 0
         _reasoning_duration_ms = 0
+        _identify_concept_chain_duration_ms = 0
 
         # ---- memory resolution (once per top-level invocation) ----
         _chain_ctx = self._received_chain_context
@@ -403,6 +404,7 @@ class ExecuteTimbrQueryChain(Chain):
                     generate_res = self._generate_sql(prompt, sql, concept_name, schema_name, error, conn_params, memory_context=memory_ctx)
                     _generate_sql_chain_duration_ms += int((_now() - _gen_start).total_seconds() * 1000)
                     _reasoning_duration_ms += generate_res.get("reasoning_duration", 0) or 0
+                    _identify_concept_chain_duration_ms += generate_res.get("identify_concept_chain_duration") or 0
                     conn_params = generate_res.get("conn_params")
                     sql = generate_res.get("sql", "")
                     ontology_name = generate_res.get("ontology", ontology_name)
@@ -466,6 +468,7 @@ class ExecuteTimbrQueryChain(Chain):
             if _generate_sql_chain_duration_ms:
                 _chain_ctx["duration"]["GenerateTimbrSqlChain"] = _generate_sql_chain_duration_ms
             _chain_ctx["duration"]["reasoning"] = _reasoning_duration_ms
+            _chain_ctx["duration"]["IdentifyTimbrConceptChain"] = _identify_concept_chain_duration_ms or None
             if identify_concept_reason:
                 _chain_ctx["reasoning"]["identify_concept_reason"] = identify_concept_reason
             if generate_sql_reason:

--- a/src/langchain_timbr/langchain/generate_answer_chain.py
+++ b/src/langchain_timbr/langchain/generate_answer_chain.py
@@ -9,6 +9,8 @@ from ..utils.timbr_llm_utils import answer_question
 from ..llm_wrapper.llm_wrapper import LlmWrapper
 from .. import config
 
+from .execute_timbr_query_chain import ExecuteTimbrQueryChain
+
 class GenerateAnswerChain(Chain):
     """
     Chain that generates an answer based on a given prompt and rows of data.
@@ -164,8 +166,6 @@ class GenerateAnswerChain(Chain):
         self._enable_logging = self._enable_trace or self._enable_history
         self._conversation_id = conversation_id
 
-
-        from .execute_timbr_query_chain import ExecuteTimbrQueryChain
         _exclude_properties = parse_list(exclude_properties) if exclude_properties is not None else ['entity_id', 'entity_type', 'entity_label']
         self._execute_chain = ExecuteTimbrQueryChain(
             llm=self._llm,
@@ -266,34 +266,6 @@ class GenerateAnswerChain(Chain):
         sql = inputs.get("sql")
         conversation_id = inputs.get("conversation_id") or self._conversation_id
 
-        # ---- memory resolution (once per top-level invocation) ----
-        _chain_ctx = self._received_chain_context
-        if _chain_ctx.get("memory") is None and self._enable_memory:
-            _chain_ctx["memory"] = resolve_memory(
-                llm=self._llm,
-                conn_params=self._get_conn_params(),
-                conversation_id=conversation_id,
-                prompt=prompt,
-                enable_memory=self._enable_memory,
-                memory_window_size=self._memory_window_size,
-                concept_names=self._concepts_list if hasattr(self, '_concepts_list') else None,
-            )
-        memory_ctx = _chain_ctx.get("memory")
-        memory_ctx = memory_ctx if isinstance(memory_ctx, MemoryContext) else None
-
-        execute_result = {}
-        if rows is None:
-            execute_result = self._execute_chain.invoke(
-                {"prompt": prompt, "conversation_id": conversation_id, "chain_context": self._received_chain_context},
-                log_ctx=self._received_log_ctx,
-            )
-            # Sync chain_context updates made by the execute chain back into our context
-            if execute_result.get("chain_context"):
-                self._received_chain_context = execute_result["chain_context"]
-            rows = execute_result.get("rows")
-            sql = execute_result.get("sql") or sql
-            conversation_id = execute_result.get("conversation_id") or conversation_id
-
         _log_ctx = self._received_log_ctx
 
         if _log_ctx is None and self._enable_logging:
@@ -314,6 +286,38 @@ class GenerateAnswerChain(Chain):
                 concept=self._concept,
             )
             log_agent_start(_log_ctx, _log_ctx.ontology, _log_ctx.schema)
+
+        # ---- memory resolution (once per top-level invocation) ----
+        _chain_ctx = self._received_chain_context
+        if _chain_ctx.get("memory") is None and self._enable_memory:
+            _chain_ctx["memory"] = resolve_memory(
+                llm=self._llm,
+                conn_params=self._get_conn_params(),
+                conversation_id=conversation_id,
+                prompt=prompt,
+                enable_memory=self._enable_memory,
+                memory_window_size=self._memory_window_size,
+                concept_names=self._concepts_list if hasattr(self, '_concepts_list') else None,
+            )
+        memory_ctx = _chain_ctx.get("memory")
+        memory_ctx = memory_ctx if isinstance(memory_ctx, MemoryContext) else None
+
+        execute_result = {}
+        if rows is None:
+            execute_result = self._execute_chain.invoke(
+                {
+                    "prompt": prompt,
+                    "conversation_id": conversation_id,
+                    "chain_context": _chain_ctx,
+                },
+                log_ctx=self._received_log_ctx,
+            )
+            # Sync chain_context updates made by the execute chain back into our context
+            if execute_result.get("chain_context"):
+                self._received_chain_context = execute_result["chain_context"]
+            rows = execute_result.get("rows")
+            sql = execute_result.get("sql") or sql
+            conversation_id = execute_result.get("conversation_id") or conversation_id
 
         if _log_ctx:
             _log_ctx.current_step = "generating_answer"
@@ -339,7 +343,6 @@ class GenerateAnswerChain(Chain):
         answer = res.get("answer", "")
         usage_metadata = res.get("usage_metadata", {})
 
-        _chain_ctx = self._received_chain_context
         _answer_duration_ms = int((_now() - _answer_start).total_seconds() * 1000)
         _chain_ctx["duration"]["GenerateAnswerChain"] = _answer_duration_ms
         _chain_ctx["tokens"]["GenerateAnswerChain"] = {

--- a/src/langchain_timbr/langchain/generate_timbr_sql_chain.py
+++ b/src/langchain_timbr/langchain/generate_timbr_sql_chain.py
@@ -352,6 +352,7 @@ class GenerateTimbrSqlChain(Chain):
         _chain_ctx = self._received_chain_context
         _chain_ctx["duration"]["GenerateTimbrSqlChain"] = _duration_ms
         _chain_ctx["duration"]["reasoning"] = generate_res.get("reasoning_duration", 0) or 0
+        _chain_ctx["duration"]["IdentifyTimbrConceptChain"] = generate_res.get("identify_concept_chain_duration")
         if generate_res.get("identify_concept_reason"):
             _chain_ctx["reasoning"]["identify_concept_reason"] = generate_res["identify_concept_reason"]
         if generate_res.get("generate_sql_reason"):

--- a/src/langchain_timbr/langchain/generate_timbr_sql_chain.py
+++ b/src/langchain_timbr/langchain/generate_timbr_sql_chain.py
@@ -261,6 +261,7 @@ class GenerateTimbrSqlChain(Chain):
             _log_ctx = AgentLogContext(
                 query_id=_query_id,
                 agent_name=self._agent or "",
+                ontology=self._ontology or "",
                 url=build_server_url(self._url, config.thrift_host, config.thrift_port),
                 token=self._token,
                 chain_type="GenerateTimbrSqlChain",

--- a/src/langchain_timbr/langchain/generate_timbr_sql_chain.py
+++ b/src/langchain_timbr/langchain/generate_timbr_sql_chain.py
@@ -351,6 +351,7 @@ class GenerateTimbrSqlChain(Chain):
         _duration_ms = int((_now() - _chain_start).total_seconds() * 1000)
         _chain_ctx = self._received_chain_context
         _chain_ctx["duration"]["GenerateTimbrSqlChain"] = _duration_ms
+        _chain_ctx["duration"]["reasoning"] = generate_res.get("reasoning_duration", 0) or 0
         if generate_res.get("identify_concept_reason"):
             _chain_ctx["reasoning"]["identify_concept_reason"] = generate_res["identify_concept_reason"]
         if generate_res.get("generate_sql_reason"):

--- a/src/langchain_timbr/langchain/identify_concept_chain.py
+++ b/src/langchain_timbr/langchain/identify_concept_chain.py
@@ -250,13 +250,13 @@ class IdentifyTimbrConceptChain(Chain):
         )
 
         usage_metadata = res.pop("usage_metadata", {})
+        _duration_ms = res.pop("duration_ms", 0)
         concept = res.get("concept")
 
         if _log_ctx:
             if concept:
                 _log_ctx.concept = concept
 
-        _duration_ms = int((_now() - _chain_start).total_seconds() * 1000)
         _chain_ctx = self._received_chain_context
         _chain_ctx["duration"]["IdentifyTimbrConceptChain"] = _duration_ms
         if res.get("identify_concept_reason"):

--- a/src/langchain_timbr/langchain/identify_concept_chain.py
+++ b/src/langchain_timbr/langchain/identify_concept_chain.py
@@ -217,6 +217,7 @@ class IdentifyTimbrConceptChain(Chain):
             _log_ctx = AgentLogContext(
                 query_id=_query_id,
                 agent_name=self._agent or "",
+                ontology=self._ontology or "",
                 url=build_server_url(self._url, config.thrift_host, config.thrift_port),
                 token=self._token,
                 chain_type="IdentifyTimbrConceptChain",

--- a/src/langchain_timbr/langchain/validate_timbr_sql_chain.py
+++ b/src/langchain_timbr/langchain/validate_timbr_sql_chain.py
@@ -250,6 +250,7 @@ class ValidateTimbrSqlChain(Chain):
             _log_ctx = AgentLogContext(
                 query_id=_query_id,
                 agent_name=self._agent or "",
+                ontology=self._ontology or "",
                 url=build_server_url(self._url, config.thrift_host, config.thrift_port),
                 token=self._token,
                 chain_type="ValidateTimbrSqlChain",

--- a/src/langchain_timbr/utils/chain_logger.py
+++ b/src/langchain_timbr/utils/chain_logger.py
@@ -106,6 +106,7 @@ def log_agent_step(ctx: AgentLogContext) -> None:
     _safe_post(ctx.url, ctx.token, "/timbr-server/log_agent/running_update_step", _clean({
         "query_id":               ctx.query_id,
         "agent_name":             ctx.agent_name,
+        "ontology":               ctx.ontology,
         "current_step":           ctx.current_step or "",
         "retry_count":            ctx.retry_count,
         "no_results_retry_count": ctx.no_results_retry_count,

--- a/src/langchain_timbr/utils/chain_logger.py
+++ b/src/langchain_timbr/utils/chain_logger.py
@@ -142,7 +142,17 @@ def log_agent_history(
 ) -> None:
     """POST to sys_agents_history — triggers server-side deletion of the running row."""
     end_time = _now()
-    duration_ms = int((end_time - ctx.start_time).total_seconds() * 1000)
+    wall_clock_ms = int((end_time - ctx.start_time).total_seconds() * 1000)
+    _sub_total_ms = sum(
+        d for d in [
+            identify_concept_chain_duration,
+            generate_sql_chain_duration,
+            answer_chain_duration,
+            reasoning_duration,
+        ]
+        if d is not None
+    )
+    duration_ms = max(wall_clock_ms, _sub_total_ms)
 
     post_params = {
         "query_id":                        ctx.query_id,

--- a/src/langchain_timbr/utils/timbr_llm_utils.py
+++ b/src/langchain_timbr/utils/timbr_llm_utils.py
@@ -816,11 +816,13 @@ def handle_generate_sql_reasoning(
     timeout: int,
     debug: bool,
     previous_token_count
-) -> tuple[str, int, str]:
+) -> tuple[str, int, str, int]:
+    import time as _time
     generate_sql_prompt = get_generate_sql_prompt_template(conn_params)
     context_graph_depth = graph_depth
     reasoned_sql = sql_query
     reasoned_sql_reason = None
+    _reasoning_start = _time.monotonic()
     for step in range(reasoning_steps):
         try:
             # Step 1: Evaluate the current SQL
@@ -896,7 +898,8 @@ def handle_generate_sql_reasoning(
             print(f"Warning: LLM reasoning failed: {e}")
             break
     
-    return reasoned_sql, context_graph_depth, reasoned_sql_reason
+    _reasoning_duration_ms = int((_time.monotonic() - _reasoning_start) * 1000)
+    return reasoned_sql, context_graph_depth, reasoned_sql_reason, _reasoning_duration_ms
 
 def handle_validate_generate_sql(
     sql_query: str,
@@ -988,6 +991,7 @@ def generate_sql(
     usage_metadata = {}
     concept_metadata = None
     reasoning_status = 'correct'
+    reasoning_duration = 0
 
     # Use config default timeout if none provided
     if timeout is None:
@@ -1073,7 +1077,7 @@ def generate_sql(
             raise Exception(error)
         
         if enable_reasoning and sql_query is not None:
-            sql_query, graph_depth, generate_sql_reason = handle_generate_sql_reasoning(
+            sql_query, graph_depth, generate_sql_reason, reasoning_duration = handle_generate_sql_reasoning(
                 sql_query=sql_query,
                 question=question,
                 llm=llm,
@@ -1132,6 +1136,7 @@ def generate_sql(
         "identify_concept_reason": identify_concept_reason,
         "generate_sql_reason": generate_sql_reason,
         "reasoning_status": reasoning_status,
+        "reasoning_duration": reasoning_duration,
         "usage_metadata": usage_metadata,
         "ontology": conn_params.get('ontology'),
         "conn_params": conn_params

--- a/src/langchain_timbr/utils/timbr_llm_utils.py
+++ b/src/langchain_timbr/utils/timbr_llm_utils.py
@@ -295,6 +295,7 @@ def determine_concept(
     timeout: Optional[int] = None,
     memory_context=None,
 ) -> dict[str, Any]:
+    _determine_concept_start = datetime.now()
     usage_metadata = {}
     determined_concept_name = None
     identify_concept_reason = None
@@ -475,7 +476,8 @@ def determine_concept(
         "schema": schema,
         "usage_metadata": usage_metadata,
         "ontology": ontology,
-        "conn_params": ontologies_conn_params.get(ontology)
+        "conn_params": ontologies_conn_params.get(ontology),
+        "duration_ms": int((datetime.now() - _determine_concept_start).total_seconds() * 1000),
     }
 
 
@@ -1024,6 +1026,8 @@ def generate_sql(
         timeout=timeout,
     )
 
+    identify_concept_chain_duration = determine_concept_res.pop("duration_ms", 0)
+
     if (type(conn_params.get('ontology')) == list and len(conn_params.get('ontology')) > 1) or ',' in conn_params.get('ontology'):
         conn_params = determine_concept_res.get('conn_params')
 
@@ -1137,6 +1141,7 @@ def generate_sql(
         "generate_sql_reason": generate_sql_reason,
         "reasoning_status": reasoning_status,
         "reasoning_duration": reasoning_duration,
+        "identify_concept_chain_duration": identify_concept_chain_duration,
         "usage_metadata": usage_metadata,
         "ontology": conn_params.get('ontology'),
         "conn_params": conn_params

--- a/tests/standard/test_sanitize_results.py
+++ b/tests/standard/test_sanitize_results.py
@@ -37,6 +37,7 @@ class TestGenerateTimbrSqlChainOutput:
             "reasoning_status": None,
             "usage_metadata": {"input_tokens": 10, "output_tokens": 5},
             "internal_llm_debug": "should_not_appear",  # extra key the util may return
+            "identify_concept_chain_duration": 55,  # consumed by _chain_ctx, must not leak to output
         }
         chain = GenerateTimbrSqlChain(llm=Mock(), url=URL, token=TOKEN)
         chain._received_chain_context = _init_chain_context(None)
@@ -99,6 +100,7 @@ class TestIdentifyTimbrConceptChainOutput:
             "identify_concept_reason": "city matched the question intent",
             "usage_metadata": {"input_tokens": 15, "output_tokens": 6},
             "internal_candidates": ["city", "country"],  # extra key that should be stripped
+            "duration_ms": 42,  # popped internally, must not leak to output
         }
         chain = IdentifyTimbrConceptChain(llm=Mock(), url=URL, token=TOKEN)
         chain._received_chain_context = _init_chain_context(None)

--- a/tests/standard/test_unit_tests.py
+++ b/tests/standard/test_unit_tests.py
@@ -10,6 +10,7 @@ from langchain_timbr import (
     GenerateAnswerChain,
 )
 from langchain_timbr.utils.timbr_llm_utils import _calculate_token_count
+from langchain_timbr.utils._base_chain import _init_chain_context
 
 
 class TestChainUnitTests:
@@ -22,7 +23,8 @@ class TestChainUnitTests:
                 'concept': 'customer',
                 'schema': 'dtimbr',
                 'concept_metadata': {},
-                'usage_metadata': {}
+                'usage_metadata': {},
+                'duration_ms': 42,
             }
             
             chain = IdentifyTimbrConceptChain(
@@ -721,3 +723,50 @@ class TestHasNoMeaningfulResults:
 
     def test_none_sql_empty_rows(self, chain):
         assert chain._has_no_meaningful_results([], None) is True
+
+
+class TestDurationTracking:
+    """Tests verifying that determine_concept duration flows through each chain into _chain_ctx."""
+
+    @patch('langchain_timbr.langchain.identify_concept_chain.determine_concept')
+    def test_identify_concept_chain_duration_sourced_from_determine_concept(self, mock_determine, mock_llm):
+        """IdentifyTimbrConceptChain must store the duration_ms returned by determine_concept, not re-time it."""
+        mock_determine.return_value = {
+            'concept': 'customer', 'schema': 'dtimbr',
+            'concept_metadata': {}, 'usage_metadata': {},
+            'duration_ms': 42,
+        }
+        chain = IdentifyTimbrConceptChain(llm=mock_llm, url="http://test", token="test", ontology="test")
+        chain._received_chain_context = _init_chain_context(None)
+        chain._call({"prompt": "test"})
+        assert chain._received_chain_context["duration"]["IdentifyTimbrConceptChain"] == 42
+
+    @patch('langchain_timbr.langchain.generate_timbr_sql_chain.generate_sql')
+    def test_generate_sql_chain_identify_concept_duration_propagated(self, mock_generate_sql, mock_llm):
+        """GenerateTimbrSqlChain must forward identify_concept_chain_duration from generate_sql into _chain_ctx."""
+        mock_generate_sql.return_value = {
+            'sql': 'SELECT 1', 'concept': 'customer', 'schema': 'dtimbr',
+            'usage_metadata': {}, 'identify_concept_chain_duration': 55,
+        }
+        chain = GenerateTimbrSqlChain(llm=mock_llm, url="http://test", token="test", ontology="test")
+        chain._received_chain_context = _init_chain_context(None)
+        chain._call({"prompt": "test"})
+        assert chain._received_chain_context["duration"]["IdentifyTimbrConceptChain"] == 55
+
+    @patch('langchain_timbr.langchain.execute_timbr_query_chain.run_query')
+    @patch('langchain_timbr.langchain.execute_timbr_query_chain.generate_sql')
+    def test_execute_query_chain_identify_concept_duration_stored(self, mock_generate_sql, mock_run_query, mock_llm):
+        """ExecuteTimbrQueryChain must accumulate identify_concept_chain_duration across iterations into _chain_ctx."""
+        mock_generate_sql.return_value = {
+            'sql': 'SELECT 1', 'concept': 'customer', 'schema': 'dtimbr',
+            'is_sql_valid': True, 'error': None, 'usage_metadata': {},
+            'reasoning_duration': 0, 'identify_concept_chain_duration': 30,
+        }
+        mock_run_query.return_value = [{"id": 1}]
+        chain = ExecuteTimbrQueryChain(
+            llm=mock_llm, url="http://test", token="test", ontology="test",
+            should_validate_sql=False,
+        )
+        chain._received_chain_context = _init_chain_context(None)
+        chain._call({"prompt": "test"})
+        assert chain._received_chain_context["duration"]["IdentifyTimbrConceptChain"] == 30


### PR DESCRIPTION
### Description
<!--- Copy a summary or requirements of the bug/features section of the JIRA ticket -->
* Move determine_concept timing into the function itself — determine_concept now self-times and returns duration_ms in its result dict, replacing the manual _now() wrapper in IdentifyTimbrConceptChain
* Propagate concept-identification duration through generate_sql — generate_sql pops duration_ms from determine_concept's result and returns it as identify_concept_chain_duration, so all callers get the metric for free
* Set _chain_ctx["duration"]["IdentifyTimbrConceptChain"] in every SQL path — GenerateTimbrSqlChain and ExecuteTimbrQueryChain (which accumulates across no-results retries) now both write this key, fixing the gap where identify_concept_chain_duration was always None in log_agent_history when going through those paths
* Fix reasoning_duration tracking — handle_generate_sql_reasoning now returns its measured duration instead of discarding it; generate_sql initialises reasoning_duration = 0 so the field is always present in the return dict; ExecuteTimbrQueryChain accumulates it across iterations
* Add ontology to AgentLogContext in IdentifyTimbrConceptChain, GenerateTimbrSqlChain, and ExecuteTimbrQueryChain constructors


### Type of Change
<!--- Check any relevant boxes with "x" -->
- [x] New feature | task (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change

### TESTS
<!--- Specify number of tests added or changed -->
Number of tests added/changed: 
* Updated test_unit_tests.py:
    * test_identify_concept_chain_unit mock now includes duration_ms
    * New TestDurationTracking class with 3 tests covering the full propagation path: determine_concept → IdentifyTimbrConceptChain, generate_sql → GenerateTimbrSqlChain, and generate_sql → ExecuteTimbrQueryChain
* Updated test_sanitize_results.py:
    * duration_ms added to the IdentifyTimbrConceptChain mock — confirms it's popped before result spread (no leak to output)
    * identify_concept_chain_duration added to the GenerateTimbrSqlChain mock — confirms it's consumed by _chain_ctx and not leaked to chain output


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Enter the ticket number as TP-XXXX format -->
- [x] JIRA Ticket: TP-3320
- [ ] Has associated issue: 
- [ ] Removes existing feature or API
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
